### PR TITLE
ignore desktop.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+desktop.ini
+


### PR DESCRIPTION
To be useful on Microsoft Windows, the file desktop.ini should always be ignored.  Windows frequently creates this file in subfolders without user intervention.